### PR TITLE
fix:解决search-key组件onSearch配置后搜索失效

### DIFF
--- a/packages/crud/src/components/search-key/index.tsx
+++ b/packages/crud/src/components/search-key/index.tsx
@@ -73,14 +73,14 @@ export default defineComponent({
 				props.fieldList.forEach((e) => {
 					params[e.value] = undefined;
 				});
-
+				params[selectField.value] = value.value || undefined;
+				
 				async function next(newParams?: obj) {
 					loading.value = true;
 
 					await crud.refresh({
 						page: 1,
 						...params,
-						[selectField.value]: value.value || undefined,
 						...newParams
 					});
 


### PR DESCRIPTION
配置onsearch后，获取的params中所有字段均为undefined，丢失搜索数据