### PR TITLE
fix: :bug: cl-table表头搜索时高度抖动

### DIFF
--- a/packages/crud/src/static/index.scss
+++ b/packages/crud/src/static/index.scss
@@ -133,6 +133,7 @@
 			align-items: center;
 			justify-content: center;
 			gap: 5px;
+			height: 32px;
 		}
 
 		&:hover {
@@ -144,6 +145,7 @@
 
 			& > div {
 				width: 100%;
+				height: 32px;
 
 				.el-date-editor {
 					margin-right: 0;


### PR DESCRIPTION
固定高度以解决cl-table表头搜索时出现的表头高度抖动问题