### PR TITLE
fix: 修复菜单图标设置后无法删除的问题

### DIFF
--- a/src/modules/base/components/menu/icon.vue
+++ b/src/modules/base/components/menu/icon.vue
@@ -4,7 +4,7 @@
 			<cl-svg :name="modelValue" />
 		</div>
 
-		<el-select v-model="value" filterable fit-input-width clearable>
+		<el-select v-model="value" filterable fit-input-width clearable @clear="onClear">
 			<div class="cl-menu-icon__list">
 				<el-option v-for="item in list" :key="item" :value="item">
 					<cl-svg :name="item" />
@@ -37,6 +37,11 @@ const list = ref(svgIcons.filter(e => e.indexOf('icon-') === 0));
 
 // 已选图标
 const value = useModel(props, 'modelValue');
+
+// 处理清空事件
+function onClear() {
+	value.value = '';
+}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
目前一旦不小心给菜单设置了图标就无法通过编辑删除。
因为点击清空按钮后value会变成undefined，导致无法传参给后台。